### PR TITLE
Granular I/O

### DIFF
--- a/examples/fd-read.bl
+++ b/examples/fd-read.bl
@@ -2,7 +2,7 @@
 ;; to read from stdin and convert Cs to a T
 ;; NOTE -> this will block and wait on input!
 
-q-new 0 read swap q-new    ;; Q for read-queue, hide FD, Q for work-queue
+0 fd fdq q-new             ;; Q for read-queue, Q for work-queue
 [
   '' swap                  ;; create empty T and bring recv Q back to top
   [ rot swap app swap ]    ;; bring T to top, then item, append item, bring Q to top

--- a/examples/fd-write.bl
+++ b/examples/fd-write.bl
@@ -1,7 +1,7 @@
 ;; Use file descriptors (N) to write to stderr
 ;; the queue acts as a communication channel to the write-thread
 
-q-new 2 write swap
+2 fd fdq
 'big' enq
 \a32 enq
 'bada' enq

--- a/examples/file-read.bl
+++ b/examples/file-read.bl
@@ -3,6 +3,6 @@
 q-new                 ;; creates a new Q that we'll use as our read-queue
 'examples/_text.txt'  ;; this is the filename we'll read from
 read                  ;; starts reading from our file in a background thread
-swap                  ;; hide the FD and being read-queue to top
+swap                  ;; hide the FD and bring read-queue to top
 q-to-t                ;; blocks until EOF and returns T
 print                 ;; prints T to stdout

--- a/examples/hello_bob.bl
+++ b/examples/hello_bob.bl
@@ -1,7 +1,7 @@
 ;; "Hello, Bob!" in blacklight
 
 'Enter your name: ' print
-q-new 0 read '' rot deq
+'' 0 fd fdq deq
 [ rot swap app swap deq ] [ dup \\n eq ] until
 drop drop
 'Hello, ' swap app '!' app \\n app print

--- a/examples/text-write-to-fd.bl
+++ b/examples/text-write-to-fd.bl
@@ -1,11 +1,11 @@
 ;; Write a T to a FD
 
-o-new
+o-new ;; o1
 
 [
   drop
-  q-new swap write drop
-  self swap out:
+  fd fdq          ;; get the FD and then get the Q from it
+  self swap out:  ;; store Q in `out` slot
 ] write:
 
 [

--- a/scripts/examples.bash
+++ b/scripts/examples.bash
@@ -32,7 +32,7 @@ ended_at=$(timer)
 
 echo
 echo " -- failures: $failures"
-echo " -- failed: ${failed-<all passed>}"
+echo " -- failed: ${failed:-<all passed>}"
 
 elapsed $started_at $ended_at
 

--- a/scripts/examples.bash
+++ b/scripts/examples.bash
@@ -14,6 +14,7 @@ if [[ ! -x $blacklight ]]; then
 fi
 
 failures=0
+failed=""
 started_at=$(timer)
 
 for file in $examples; do

--- a/src/blacklight.go
+++ b/src/blacklight.go
@@ -32,6 +32,7 @@ func main() {
 	}
 
 	prepare_op_table()
+	initFDtable()
 
 	tokens := parse(code)
 

--- a/src/blacklight.go
+++ b/src/blacklight.go
@@ -22,8 +22,6 @@ func main() {
 	var fileName string
 	var code []rune
 
-	prepare_op_table()
-
 	if len(os.Args[1:]) == 1 {
 		fileName = os.Args[1]
 		code = loadFile(fileName)
@@ -32,6 +30,8 @@ func main() {
 	} else {
 		panic("no filename argument")
 	}
+
+	prepare_op_table()
 
 	tokens := parse(code)
 

--- a/src/bytecodes.go
+++ b/src/bytecodes.go
@@ -94,6 +94,8 @@ func prepare_op_table() {
 		// file io
 		"read":  read,
 		"write": write,
+		"fd":    fd,
+		"fdq":   fdq,
 
 		// logic & loops
 		"either": bl_either,

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -304,16 +304,16 @@ func n_to_t(m *Meta) {
 // IO
 
 func read(m *Meta) {
-	source := m.Current().Pop()
+	source := m.Current().Pop().(T)
 	q := m.Current().Peek().(*Queue)
-	io := ReadIO(source, q)
+	io := ReadFile(source, q)
 	m.Current().Push(io)
 }
 
 func write(m *Meta) {
-	dest := m.Current().Pop()
+	dest := m.Current().Pop().(T)
 	q := m.Current().Peek().(*Queue)
-	io := WriteIO(dest, q)
+	io := WriteFile(dest, q)
 	m.Current().Push(io)
 }
 

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -317,6 +317,16 @@ func write(m *Meta) {
 	m.Current().Push(io)
 }
 
+func fd(m *Meta) {
+	m.Current().Push(GetFD(m.Current().Pop().(N)))
+}
+
+func fdq(m *Meta) {
+	fdt := m.Current().Pop().(*Tag)
+	fdq := GetFDQ(fdt)
+	m.Current().Push(fdq)
+}
+
 // LOGIC AND LOOPS
 
 func bl_either(m *Meta) {

--- a/src/io.go
+++ b/src/io.go
@@ -17,32 +17,6 @@ type IO struct {
 	Mode  uint // 01 read, 10 write
 }
 
-func ReadIO(i datatypes, q *Queue) *Tag {
-	switch i.(type) {
-	case N:
-		fd := ReadFD(int(i.(N)), q)
-		return NewFDTag(i.Print(), fd)
-	case T:
-		file := ReadFile(i.Print(), q)
-		return NewFileTag("File#"+i.Print(), file)
-	default:
-		panic("ReadIO: unrecognized type for IO - " + i.Print())
-	}
-}
-
-func WriteIO(i datatypes, q *Queue) *Tag {
-	switch i.(type) {
-	case N:
-		fd := WriteFD(int(i.(N)), q)
-		return NewFDTag("FD#"+i.Print(), fd)
-	case T:
-		file := WriteFile(i.Print(), q)
-		return NewFileTag("File#"+i.Print(), file)
-	default:
-		panic("WriteIO: unrecognized type for IO - " + i.Print())
-	}
-}
-
 var FDtable map[uint]*IO = make(map[uint]*IO)
 
 func initFDtable() {
@@ -121,11 +95,11 @@ func WriteFD(i int, q *Queue) *IO {
 	return fd
 }
 
-func ReadFile(filename string, q *Queue) *IO {
+func ReadFile(filename T, q *Queue) *Tag {
 	fd := new(IO)
 	fd.Mode = IO_READ
 	fd.Queue = q
-	fd.File, _ = os.Open(filename)
+	fd.File, _ = os.Open(string(filename))
 	fd.FD = uint(fd.File.Fd())
 
 	FDtable[fd.FD] = fd
@@ -147,14 +121,14 @@ func ReadFile(filename string, q *Queue) *IO {
 		}
 	}(fd, q)
 
-	return fd
+	return NewFileTag("File#"+filename.Print(), fd)
 }
 
-func WriteFile(filename string, q *Queue) *IO {
+func WriteFile(filename T, q *Queue) *Tag {
 	fd := new(IO)
 	fd.Mode = IO_WRITE
 	fd.Queue = q
-	fd.File, _ = os.Create(filename)
+	fd.File, _ = os.Create(string(filename))
 	fd.FD = uint(fd.File.Fd())
 
 	FDtable[fd.FD] = fd
@@ -179,5 +153,5 @@ func WriteFile(filename string, q *Queue) *IO {
 		}
 	}(fd, q)
 
-	return fd
+	return NewFileTag("File#"+filename.Print(), fd)
 }

--- a/src/io.go
+++ b/src/io.go
@@ -40,15 +40,11 @@ func WriteIO(i datatypes, q *Queue) *Tag {
 }
 
 var FDtable map[uint]*os.File = make(map[uint]*os.File)
-var FDtableinit bool
 
 func initFDtable() {
-	if !FDtableinit {
-		FDtable[0] = os.Stdin
-		FDtable[1] = os.Stdout
-		FDtable[2] = os.Stderr
-		FDtableinit = true
-	}
+	FDtable[0] = os.Stdin
+	FDtable[1] = os.Stdout
+	FDtable[2] = os.Stderr
 }
 
 type FD struct {
@@ -58,7 +54,6 @@ type FD struct {
 }
 
 func ReadFD(i int, q *Queue) *FD {
-	initFDtable()
 	fd := new(FD)
 	fd.Queue = q
 	fd.FD = uint(i)
@@ -84,7 +79,6 @@ func ReadFD(i int, q *Queue) *FD {
 }
 
 func WriteFD(i int, q *Queue) *FD {
-	initFDtable()
 	fd := new(FD)
 	fd.Queue = q
 	fd.FD = uint(i)

--- a/src/io.go
+++ b/src/io.go
@@ -4,11 +4,17 @@ import (
 	"os"
 )
 
+const (
+	IO_READ = iota
+	IO_WRITE
+)
+
 type IO struct {
 	Name  string
 	Queue *Queue
 	FD    uint
 	File  *os.File
+	Mode  uint // 01 read, 10 write
 }
 
 func ReadIO(i datatypes, q *Queue) *Tag {
@@ -44,6 +50,7 @@ func initFDtable() {
 	stdin.Name = "stdin"
 	stdin.FD = 0
 	stdin.File = os.Stdin
+	stdin.Mode = IO_READ
 
 	FDtable[0] = stdin
 
@@ -51,6 +58,7 @@ func initFDtable() {
 	stdout.Name = "stdout"
 	stdout.FD = 0
 	stdout.File = os.Stdout
+	stdout.Mode = IO_WRITE
 
 	FDtable[1] = stdout
 
@@ -58,6 +66,7 @@ func initFDtable() {
 	stderr.Name = "stderr"
 	stderr.FD = 0
 	stderr.File = os.Stderr
+	stderr.Mode = IO_WRITE
 
 	FDtable[2] = stderr
 }
@@ -114,6 +123,7 @@ func WriteFD(i int, q *Queue) *IO {
 
 func ReadFile(filename string, q *Queue) *IO {
 	fd := new(IO)
+	fd.Mode = IO_READ
 	fd.Queue = q
 	fd.File, _ = os.Open(filename)
 	fd.FD = uint(fd.File.Fd())
@@ -142,6 +152,7 @@ func ReadFile(filename string, q *Queue) *IO {
 
 func WriteFile(filename string, q *Queue) *IO {
 	fd := new(IO)
+	fd.Mode = IO_WRITE
 	fd.Queue = q
 	fd.File, _ = os.Create(filename)
 	fd.FD = uint(fd.File.Fd())

--- a/src/io.go
+++ b/src/io.go
@@ -10,7 +10,7 @@ const (
 )
 
 type IO struct {
-	Name  string
+	Name  T
 	Queue *Queue
 	FD    uint
 	File  *os.File
@@ -30,7 +30,7 @@ func initFDtable() {
 
 	stdout := new(IO)
 	stdout.Name = "stdout"
-	stdout.FD = 0
+	stdout.FD = 1
 	stdout.File = os.Stdout
 	stdout.Mode = IO_WRITE
 
@@ -38,7 +38,7 @@ func initFDtable() {
 
 	stderr := new(IO)
 	stderr.Name = "stderr"
-	stderr.FD = 0
+	stderr.FD = 2
 	stderr.File = os.Stderr
 	stderr.Mode = IO_WRITE
 

--- a/src/tag.go
+++ b/src/tag.go
@@ -49,13 +49,13 @@ func NewNil(label string) *Tag {
 	return t
 }
 
-func NewFDTag(label string, handle *FD) *Tag {
+func NewFDTag(label string, handle *IO) *Tag {
 	t := NewTag("FD", label)
 	t.Data = handle
 	return t
 }
 
-func NewFileTag(label string, handle *FD) *Tag {
+func NewFileTag(label string, handle *IO) *Tag {
 	t := NewTag("FILE", label)
 	t.Data = handle
 	return t


### PR DESCRIPTION
original Trello card: https://trello.com/c/YUdXTuGS/116-io-ops-are-too-dynamic

> The read and write ops are the only ops that determine their function dynamically, this is handy for scripting, but since the primitives aren't exposed it's harder to compose into higher level constructs, and overall seems ridiculous for a VM to do.

Operations:
- [x] filename -> FD (read only)
- [x] filename -> FD (write only - truncate)
- [x] N -> get FD at N
- [x] FD -> Q (get Queue from FD) 

Updates:
- [x]   `initFDtable()` should be run at startup, remove `FDtableinit`.
- [x] Store mode in FD struct

Out of scope:
- other file modes
- file closing
- error handling
