### PR TITLE
Handling Windows carriage returns

### DIFF
--- a/examples/hello_bob.bl
+++ b/examples/hello_bob.bl
@@ -2,6 +2,8 @@
 
 'Enter your name: ' print
 '' 0 fd fdq deq
-[ rot swap app swap deq ] [ dup \\n eq ] until
+[ rot swap app swap deq ] [
+   [ true ] [ dup \\r eq ] [ dup \\n eq ] either 
+] until
 drop drop
 'Hello, ' swap app '!' app \\n app print


### PR DESCRIPTION
The output from the previous version on Windows was `!ello, Bob` due to the carriage return and overwriting the first character.
