### PR TITLE
better errors part 1

### DIFF
--- a/examples/should_fail/invalid_instructions.bl
+++ b/examples/should_fail/invalid_instructions.bl
@@ -1,0 +1,7 @@
+;; running this file should cause blacklight to exit with an error
+;; because it contains invalid instructions
+
+1 2 3 4
+print say print INVALID_INSTRUCTION refl
+5 6 7 8
+say print say TOTES_INVALID 9 10

--- a/src/blacklight.go
+++ b/src/blacklight.go
@@ -35,7 +35,9 @@ func main() {
 	prepare_op_table()
 	initFDtable()
 
-	tokens := parse(code)
+	source := NewSource(fileName)
+	source.code = code
+	source = parse(source)
 
 	/*
 		tokens, err := parse(code)
@@ -44,7 +46,7 @@ func main() {
 		}
 	*/
 
-	ops, err := compile(tokens, fileName)
+	ops, err := compile(source.tokens, fileName)
 
 	if err != nil {
 		exitWithError(3, err)

--- a/src/blacklight.go
+++ b/src/blacklight.go
@@ -29,7 +29,8 @@ func main() {
 		fileName = "<cmdline>"
 		code = []rune(os.Args[2])
 	} else {
-		panic("no filename argument")
+		usage("no filename argument")
+		exit(1)
 	}
 
 	prepare_op_table()
@@ -40,8 +41,7 @@ func main() {
 	ops, err := compile(tokens, fileName)
 
 	if err != nil {
-		print(err.Error(), "\n")
-		os.Exit(1)
+		exitWithError(3, err)
 	}
 
 	doVM(ops)
@@ -71,4 +71,23 @@ func cleanup() {
 		warn("encountered an error and had to quit: ")
 		panic(err)
 	}
+}
+
+func usage(msg string) {
+	info := "## blacklight usage ##\nblacklight path/to/file.bl\nblacklight -e \"'hello world' say\"\n"
+	if msg == "" {
+		print(info)
+	} else {
+		warn(msg, "\n", info)
+	}
+}
+
+func exitWithError(code int, err error) {
+	warn(err.Error(), "\n")
+	exit(code)
+}
+
+func exit(code int) {
+	cleanup()
+	os.Exit(code)
 }

--- a/src/blacklight.go
+++ b/src/blacklight.go
@@ -26,6 +26,7 @@ func main() {
 		fileName = os.Args[1]
 		code = loadFile(fileName)
 	} else if len(os.Args[1:]) == 2 {
+		fileName = "<cmdline>"
 		code = []rune(os.Args[2])
 	} else {
 		panic("no filename argument")
@@ -36,7 +37,12 @@ func main() {
 
 	tokens := parse(code)
 
-	ops := compile(tokens)
+	ops, err := compile(tokens, fileName)
+
+	if err != nil {
+		print(err.Error(), "\n")
+		os.Exit(1)
+	}
 
 	doVM(ops)
 }

--- a/src/blacklight.go
+++ b/src/blacklight.go
@@ -30,7 +30,6 @@ func main() {
 		code = []rune(os.Args[2])
 	} else {
 		usage("no filename argument")
-		exit(1)
 	}
 
 	prepare_op_table()
@@ -74,11 +73,13 @@ func cleanup() {
 }
 
 func usage(msg string) {
-	info := "## blacklight usage ##\nblacklight path/to/file.bl\nblacklight -e \"'hello world' say\"\n"
+	info := "## blacklight usage ##\nblacklight path/to/file.bl\nblacklight -e \"'hello world' say\""
 	if msg == "" {
 		print(info)
+		exit(0)
 	} else {
 		warn(msg, "\n", info)
+		exit(1)
 	}
 }
 

--- a/src/blacklight.go
+++ b/src/blacklight.go
@@ -37,6 +37,13 @@ func main() {
 
 	tokens := parse(code)
 
+	/*
+		tokens, err := parse(code)
+		if err != nil {
+			exitWithError(2, err)
+		}
+	*/
+
 	ops, err := compile(tokens, fileName)
 
 	if err != nil {

--- a/src/blacklight.go
+++ b/src/blacklight.go
@@ -46,7 +46,7 @@ func main() {
 		}
 	*/
 
-	ops, err := compile(source.tokens, fileName)
+	ops, err := compile(source)
 
 	if err != nil {
 		exitWithError(3, err)

--- a/src/code.go
+++ b/src/code.go
@@ -1,0 +1,15 @@
+package main
+
+type Source struct {
+	filename  string
+	code      []rune
+	tokens    []string
+	sourcemap map[int]int
+}
+
+func NewSource(filename string) *Source {
+	source := new(Source)
+	source.filename = filename
+	source.sourcemap = make(map[int]int)
+	return source
+}

--- a/src/code.go
+++ b/src/code.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"runtime"
+	"strconv"
+)
+
 type Source struct {
 	filename  string
 	code      []rune
@@ -12,4 +17,17 @@ func NewSource(filename string) *Source {
 	source.filename = filename
 	source.sourcemap = make(map[int]int)
 	return source
+}
+
+func GoDebug(offset int) (file string, line string) {
+	_, file, lineno, ok := runtime.Caller(1)
+
+	if ok {
+		line = strconv.Itoa(lineno + offset)
+	} else {
+		file = "<unknown>"
+		line = "<unknown>"
+	}
+
+	return file, line
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -193,12 +193,13 @@ func compile(source *Source) ([]byte, error) {
 
 			var info sequence
 			info = new(V)
-			info = info.App(NewTag("ERR_FILE", "compiler.go"))
-			info = info.App(NewTag("ERR_LINE", "181"))
 			info = info.App(NewTag("BL_FILE", source.filename))
 			info = info.App(NewTag("BL_LINE", strconv.Itoa(bl_line)))
 			info = info.App(NewTag("BL_OFFSET", strconv.Itoa(bl_offset)))
 			info = info.App(NewTag("TOKEN_OFFSET", strconv.Itoa(i)))
+			info = info.App(NewTag("ERR_FILE", "compiler.go"))
+			info = info.App(NewTag("ERR_LINE", "181"))
+
 			err := NewErr("compiler: unrecognized operation: "+t, info)
 			return nil, err
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -181,8 +181,8 @@ func compile(tokens []string, filename string) ([]byte, error) {
 			info = new(V)
 			info = info.App(NewTag("ERR_FILE", "compiler.go"))
 			info = info.App(NewTag("ERR_LINE", "179"))
-			info = info.App(NewTag("BL_FILE", "?"))
-			info = info.App(NewTag("BL_LINE", "179"))
+			info = info.App(NewTag("BL_FILE", filename))
+			info = info.App(NewTag("BL_LINE", "??"))
 			err := NewErr("compiler: unrecognized operation: "+t, info)
 			return nil, err
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -22,7 +22,7 @@ func (d *Debug) Rescue() {
 	}
 }
 
-func compile(tokens []string) []byte {
+func compile(tokens []string, filename string) ([]byte, error) {
 	var debug = new(Debug)
 	defer debug.Rescue()
 
@@ -177,7 +177,14 @@ func compile(tokens []string) []byte {
 			}
 
 		default:
-			panic("compiler: unrecognized operation: " + t)
+			var info sequence
+			info = new(V)
+			info = info.App(NewTag("ERR_FILE", "compiler.go"))
+			info = info.App(NewTag("ERR_LINE", "179"))
+			info = info.App(NewTag("BL_FILE", "?"))
+			info = info.App(NewTag("BL_LINE", "179"))
+			err := NewErr("compiler: unrecognized operation: "+t, info)
+			return nil, err
 		}
 	}
 
@@ -188,7 +195,7 @@ func compile(tokens []string) []byte {
 		panic("compiler: unclosed paren in V literal")
 	}
 
-	return bc
+	return bc, nil
 }
 
 var rev_wd_map = make(map[string]uint64)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -179,15 +179,22 @@ func compile(source *Source) ([]byte, error) {
 			}
 
 		default:
-			bl_offset := source.sourcemap[i]
+			bl_byte_offset := source.sourcemap[i]
 
 			bl_line := 1
+			bl_line_col := 1
 			for ii, rr := range source.code {
-				if ii >= bl_offset {
+				if ii >= bl_byte_offset {
+					// bl_line_col will be at the end of the token at this point
+					// so subtract the length of the token to get the beginning
+					// len will be 1 longer than we want, so add 1 to it
+					bl_line_col = 1 + bl_line_col - len(source.tokens[i])
 					break
 				}
+				bl_line_col = bl_line_col + 1
 				if rr == rune('\n') {
 					bl_line = bl_line + 1
+					bl_line_col = 1
 				}
 			}
 
@@ -197,7 +204,8 @@ func compile(source *Source) ([]byte, error) {
 			info = new(V)
 			info = info.App(NewTag("BL_FILE", source.filename))
 			info = info.App(NewTag("BL_LINE", strconv.Itoa(bl_line)))
-			info = info.App(NewTag("BL_OFFSET", strconv.Itoa(bl_offset)))
+			info = info.App(NewTag("BL_LINE_COL", strconv.Itoa(bl_line_col)))
+			info = info.App(NewTag("BL_BYTE_OFFSET", strconv.Itoa(bl_byte_offset)))
 			info = info.App(NewTag("TOKEN_OFFSET", strconv.Itoa(i)))
 			info = info.App(NewTag("GO_FILE", gofile))
 			info = info.App(NewTag("GO_LINE", goline))

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -179,39 +179,7 @@ func compile(source *Source) ([]byte, error) {
 			}
 
 		default:
-			bl_byte_offset := source.sourcemap[i]
-
-			bl_line := 1
-			bl_line_col := 1
-			for ii, rr := range source.code {
-				if ii >= bl_byte_offset {
-					// bl_line_col will be at the end of the token at this point
-					// so subtract the length of the token to get the beginning
-					// len will be 1 longer than we want, so add 1 to it
-					bl_line_col = 1 + bl_line_col - len(source.tokens[i])
-					break
-				}
-				bl_line_col = bl_line_col + 1
-				if rr == rune('\n') {
-					bl_line = bl_line + 1
-					bl_line_col = 1
-				}
-			}
-
-			gofile, goline := GoDebug(-13)
-
-			var info sequence
-			info = new(V)
-			info = info.App(NewTag("BL_FILE", source.filename))
-			info = info.App(NewTag("BL_LINE", strconv.Itoa(bl_line)))
-			info = info.App(NewTag("BL_LINE_COL", strconv.Itoa(bl_line_col)))
-			info = info.App(NewTag("BL_BYTE_OFFSET", strconv.Itoa(bl_byte_offset)))
-			info = info.App(NewTag("TOKEN_OFFSET", strconv.Itoa(i)))
-			info = info.App(NewTag("GO_FILE", gofile))
-			info = info.App(NewTag("GO_LINE", goline))
-
-			err := NewErr("compiler: unrecognized operation: "+t, info)
-			return nil, err
+			return nil, compilation_error(source, i, t)
 		}
 	}
 
@@ -223,6 +191,42 @@ func compile(source *Source) ([]byte, error) {
 	}
 
 	return bc, nil
+}
+
+func compilation_error(source *Source, token_offset int, t string) error {
+	bl_byte_offset := source.sourcemap[token_offset]
+
+	bl_line := 1
+	bl_line_col := 1
+	for ii, rr := range source.code {
+		if ii >= bl_byte_offset {
+			// bl_line_col will be at the end of the token at this point
+			// so subtract the length of the token to get the beginning
+			// len will be 1 longer than we want, so add 1 to it
+			bl_line_col = 1 + bl_line_col - len(source.tokens[token_offset])
+			break
+		}
+		bl_line_col = bl_line_col + 1
+		if rr == rune('\n') {
+			bl_line = bl_line + 1
+			bl_line_col = 1
+		}
+	}
+
+	gofile, goline := GoDebug(-13)
+
+	var info sequence
+	info = new(V)
+	info = info.App(NewTag("BL_FILE", source.filename))
+	info = info.App(NewTag("BL_LINE", strconv.Itoa(bl_line)))
+	info = info.App(NewTag("BL_LINE_COL", strconv.Itoa(bl_line_col)))
+	info = info.App(NewTag("BL_BYTE_OFFSET", strconv.Itoa(bl_byte_offset)))
+	info = info.App(NewTag("TOKEN_OFFSET", strconv.Itoa(token_offset)))
+	info = info.App(NewTag("GO_FILE", gofile))
+	info = info.App(NewTag("GO_LINE", goline))
+
+	err := NewErr("compiler: unrecognized operation: "+t, info)
+	return err
 }
 
 var rev_wd_map = make(map[string]uint64)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -191,14 +191,16 @@ func compile(source *Source) ([]byte, error) {
 				}
 			}
 
+			gofile, goline := GoDebug(-13)
+
 			var info sequence
 			info = new(V)
 			info = info.App(NewTag("BL_FILE", source.filename))
 			info = info.App(NewTag("BL_LINE", strconv.Itoa(bl_line)))
 			info = info.App(NewTag("BL_OFFSET", strconv.Itoa(bl_offset)))
 			info = info.App(NewTag("TOKEN_OFFSET", strconv.Itoa(i)))
-			info = info.App(NewTag("ERR_FILE", "compiler.go"))
-			info = info.App(NewTag("ERR_LINE", "181"))
+			info = info.App(NewTag("GO_FILE", gofile))
+			info = info.App(NewTag("GO_LINE", goline))
 
 			err := NewErr("compiler: unrecognized operation: "+t, info)
 			return nil, err

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -191,7 +191,11 @@ func co(m *Meta) {
 	source := NewSource(filename)
 	source.code = loadFile(filename)
 	source = parse(source)
-	file_bc, _ := compile(source)
+	file_bc, err := compile(source)
+
+	if err != nil {
+		exitWithError(3, err)
+	}
 
 	m.Current().Push(out)
 	m.Current().Push(in)

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -188,9 +188,10 @@ func co(m *Meta) {
 	stack.Push(in)
 	stack.Push(out)
 
-	code := loadFile(filename)
-	tokens := parse(code)
-	file_bc, _ := compile(tokens, filename)
+	source := NewSource(filename)
+	source.code = loadFile(filename)
+	source = parse(source)
+	file_bc, _ := compile(source.tokens, filename)
 
 	m.Current().Push(out)
 	m.Current().Push(in)
@@ -242,9 +243,10 @@ func bl_warn(m *Meta) {
 func do(m *Meta) {
 	filename := string(m.Current().Pop().(T))
 
-	code := loadFile(filename)
-	tokens := parse(code)
-	file_bc, _ := compile(tokens, filename)
+	source := NewSource(filename)
+	source.code = loadFile(filename)
+	source = parse(source)
+	file_bc, _ := compile(source.tokens, filename)
 
 	doBC(m, file_bc)
 }
@@ -252,9 +254,10 @@ func do(m *Meta) {
 func bload(m *Meta) {
 	filename := string(m.Current().Pop().(T))
 
-	code := loadFile(filename)
-	tokens := parse(code)
-	file_bc, _ := compile(tokens, filename)
+	source := NewSource(filename)
+	source.code = loadFile(filename)
+	source = parse(source)
+	file_bc, _ := compile(source.tokens, filename)
 	m.Current().Push(B(file_bc))
 }
 
@@ -651,9 +654,11 @@ func t_to_cv(m *Meta) {
 }
 
 func t_to_b(m *Meta) {
-	code := []rune(string(m.Current().Pop().(T)))
-	tokens := parse(code)
-	ops, _ := compile(tokens, "<t-to-b>")
+	source := new(Source)
+	source.filename = "<t-to-b>"
+	source.code = []rune(string(m.Current().Pop().(T)))
+	source = parse(source)
+	ops, _ := compile(source.tokens, "<t-to-b>")
 	b := B(ops)
 	m.Current().Push(b)
 }

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -658,8 +658,7 @@ func t_to_cv(m *Meta) {
 }
 
 func t_to_b(m *Meta) {
-	source := new(Source)
-	source.filename = "<t-to-b>"
+	source := NewSource("<t-to-b>")
 	source.code = []rune(string(m.Current().Pop().(T)))
 	source = parse(source)
 	ops, _ := compile(source)

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -191,7 +191,7 @@ func co(m *Meta) {
 	source := NewSource(filename)
 	source.code = loadFile(filename)
 	source = parse(source)
-	file_bc, _ := compile(source.tokens, filename)
+	file_bc, _ := compile(source)
 
 	m.Current().Push(out)
 	m.Current().Push(in)
@@ -246,7 +246,7 @@ func do(m *Meta) {
 	source := NewSource(filename)
 	source.code = loadFile(filename)
 	source = parse(source)
-	file_bc, _ := compile(source.tokens, filename)
+	file_bc, _ := compile(source)
 
 	doBC(m, file_bc)
 }
@@ -257,7 +257,7 @@ func bload(m *Meta) {
 	source := NewSource(filename)
 	source.code = loadFile(filename)
 	source = parse(source)
-	file_bc, _ := compile(source.tokens, filename)
+	file_bc, _ := compile(source)
 	m.Current().Push(B(file_bc))
 }
 
@@ -658,7 +658,7 @@ func t_to_b(m *Meta) {
 	source.filename = "<t-to-b>"
 	source.code = []rune(string(m.Current().Pop().(T)))
 	source = parse(source)
-	ops, _ := compile(source.tokens, "<t-to-b>")
+	ops, _ := compile(source)
 	b := B(ops)
 	m.Current().Push(b)
 }

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -190,7 +190,7 @@ func co(m *Meta) {
 
 	code := loadFile(filename)
 	tokens := parse(code)
-	file_bc := compile(tokens)
+	file_bc, _ := compile(tokens, filename)
 
 	m.Current().Push(out)
 	m.Current().Push(in)
@@ -244,7 +244,7 @@ func do(m *Meta) {
 
 	code := loadFile(filename)
 	tokens := parse(code)
-	file_bc := compile(tokens)
+	file_bc, _ := compile(tokens, filename)
 
 	doBC(m, file_bc)
 }
@@ -254,7 +254,7 @@ func bload(m *Meta) {
 
 	code := loadFile(filename)
 	tokens := parse(code)
-	file_bc := compile(tokens)
+	file_bc, _ := compile(tokens, filename)
 	m.Current().Push(B(file_bc))
 }
 
@@ -653,7 +653,7 @@ func t_to_cv(m *Meta) {
 func t_to_b(m *Meta) {
 	code := []rune(string(m.Current().Pop().(T)))
 	tokens := parse(code)
-	ops := compile(tokens)
+	ops, _ := compile(tokens, "<t-to-b>")
 	b := B(ops)
 	m.Current().Push(b)
 }

--- a/src/parser.go
+++ b/src/parser.go
@@ -4,14 +4,14 @@ import (
 	"unicode"
 )
 
-func parse(code []rune) []string {
+func parse(source *Source) *Source {
 	var tokens []string
 	tokens = append(tokens, "")
 	l := 0
 	comment, str := false, false
 	var last_glyph rune
 
-	for _, b := range code {
+	for i, b := range source.code {
 		glyph := b
 
 		switch {
@@ -39,6 +39,7 @@ func parse(code []rune) []string {
 			t := tokens[l]
 			h := tokens[:l]
 			tokens = append(h, (t + string(glyph)))
+			source.sourcemap[len(tokens)-1] = i
 		case glyph == '(':
 			fallthrough
 		case glyph == ')':
@@ -63,7 +64,8 @@ func parse(code []rune) []string {
 		tokens = tokens[:l]
 	}
 
-	return tokens
+	source.tokens = tokens
+	return source
 }
 
 func tk(glyph rune, tokens []string) []string {

--- a/src/tag.go
+++ b/src/tag.go
@@ -7,6 +7,19 @@ type Tag struct {
 	Bool  bool
 }
 
+func (t Tag) Error() string {
+	out := t.Print()
+
+	switch t.Data.(type) {
+	case sequence:
+		out = out + "\n" + t.Data.(sequence).Print()
+	case *IO:
+		out = out + "<IO>"
+	}
+
+	return out
+}
+
 func (t Tag) Refl() string {
 	return t.Print()
 }

--- a/src/tag.go
+++ b/src/tag.go
@@ -8,11 +8,11 @@ type Tag struct {
 }
 
 func (t Tag) Error() string {
-	out := t.Print()
+	out := t.Refl()
 
 	switch t.Data.(type) {
 	case sequence:
-		out = out + "\n" + t.Data.(sequence).Print()
+		out = out + "\n" + t.Data.(sequence).Refl()
 	case *IO:
 		out = out + "<IO>"
 	}
@@ -21,10 +21,6 @@ func (t Tag) Error() string {
 }
 
 func (t Tag) Refl() string {
-	return t.Print()
-}
-
-func (t Tag) Print() string {
 	return t.Kind + "#" + t.Label
 }
 


### PR DESCRIPTION
This isn't the end-all-be-all of errors, more work will be done in the future, but figuring out where in a file the error occured is indeterminable from Go `panic` dumps, so leads to a lot of guesswork.

Errors should say which...

- source file
- token name
- line in the source file 
- column on that line in the source file

..the error occured on.

Including which Go file/line the error was generated on is useful too. The token number and raw byte offset in the `.bl` source is good for debugging how tokens are parsed, but might be removed later. Most of the info in this paragraph already exists.

- [x] source mapping (in-memory only)
- [x] CLI argument errors
- [x] Compiler errors when encountering invalid tokens