### PR TITLE
Noprint

### DIFF
--- a/examples/advanced/vector_superpowers.bl
+++ b/examples/advanced/vector_superpowers.bl
@@ -6,10 +6,10 @@
 
 ;; simple operation grouping can be done
 ( 2 2 add )
-@ say                           ;;=> (4)
+@ refl say                           ;;=> (4)
 
 ;; you can access the previous system-stack in the normal way
 ;; using the ^ (last-stack) operation
 ( ( 1 ) ^ pop swap drop ( 2 ) )
-@ say                           ;;=> ((1) (4) (2))
+@ refl say                           ;;=> ((1) (4) (2))
 

--- a/src/bytecodes.go
+++ b/src/bytecodes.go
@@ -72,7 +72,7 @@ func prepare_op_table() {
 		"wait": wait,
 
 		// debug
-		"say":   bl_println,
+		"say":   bl_say,
 		"print": bl_print,
 		"refl":  bl_refl,
 		"warn":  bl_warn,

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -219,7 +219,7 @@ func wait(m *Meta) {
 
 // DEBUG
 
-func bl_println(m *Meta) {
+func bl_say(m *Meta) {
 	i := m.Current().Pop()
 	switch i.(type) {
 	case T:

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -220,7 +220,7 @@ func wait(m *Meta) {
 // DEBUG
 
 func bl_println(m *Meta) {
-	print(m.Current().Pop().Print(), "\n")
+	print(m.Current().Pop().Refl(), "\n")
 }
 
 func bl_refl(m *Meta) {

--- a/src/instructions.go
+++ b/src/instructions.go
@@ -220,7 +220,13 @@ func wait(m *Meta) {
 // DEBUG
 
 func bl_println(m *Meta) {
-	print(m.Current().Pop().Refl(), "\n")
+	i := m.Current().Pop()
+	switch i.(type) {
+	case T:
+		print(i.(T), "\n")
+	default:
+		print(i.Refl(), "\n")
+	}
 }
 
 func bl_refl(m *Meta) {

--- a/src/item_interfaces.go
+++ b/src/item_interfaces.go
@@ -1,13 +1,11 @@
 package main
 
 type datatypes interface {
-	Print() string
 	Refl() string
 	Value() interface{}
 }
 
 type sequence interface {
-	Print() string
 	Refl() string
 	Value() interface{}
 	Cat(sequence) sequence
@@ -26,7 +24,6 @@ type byter interface {
 }
 
 type stackable interface {
-	Print() string
 	Refl() string
 	Value() interface{}
 	Push(datatypes)

--- a/src/meta.go
+++ b/src/meta.go
@@ -24,21 +24,11 @@ func (m Meta) Value() interface{} {
 	return m
 }
 
-func (m Meta) Print() string {
-	str := "$< "
-
-	for _, i := range m.Items {
-		str += i.Print() + " "
-	}
-
-	return str + ">"
-}
-
 func (m Meta) Refl() string {
 	str := "$" + strconv.Itoa(m.ID) + "#" + strconv.Itoa(m.Depth()) + "< "
 
 	for _, i := range m.Items {
-		str += i.Print() + " "
+		str += i.Refl() + " "
 	}
 
 	return str + ">"

--- a/src/object.go
+++ b/src/object.go
@@ -24,7 +24,7 @@ func (o *Object) Set(w W, i datatypes) {
 func (o *Object) Fetch(w W) datatypes {
 	i, found := o.Slots[w]
 	if !found {
-		panic("Object.Fetch: slot `" + w.Print() + "` does not exist!")
+		panic("Object.Fetch: slot `" + w.Refl() + "` does not exist!")
 	}
 	return i
 }
@@ -38,10 +38,10 @@ func (o *Object) Get(meta *Meta, w W) {
 	if !ok {
 		print("\n")
 		print("error in Object.Get: ")
-		print("slot `", w.Print(), "` not found!\n")
-		print(" -- given: ", w.Print(), "\n")
-		print(" --   has: ", o.Labels().Print(), "\n")
-		panic("Object.Get: slot `" + w.Print() + "` does not exist!")
+		print("slot `", w.Refl(), "` not found!\n")
+		print(" -- given: ", w.Refl(), "\n")
+		print(" --   has: ", o.Labels().Refl(), "\n")
+		panic("Object.Get: slot `" + w.Refl() + "` does not exist!")
 	}
 }
 
@@ -63,18 +63,14 @@ func (o *Object) DeleGet(meta *Meta, w W) bool {
 	return found
 }
 
-func (o Object) Print() string {
+func (o Object) Refl() string {
 	str := "OBJ< "
 
 	for k, v := range o.Slots {
-		str += k.Print() + ":" + v.Print() + " "
+		str += k.Refl() + ":" + v.Refl() + " "
 	}
 
 	return str + ">"
-}
-
-func (o Object) Refl() string {
-	return o.Print()
 }
 
 func (o Object) Value() interface{} {

--- a/src/object_stack.go
+++ b/src/object_stack.go
@@ -31,16 +31,6 @@ func (s *ObjectStack) Refl() string {
 	return str + " >"
 }
 
-func (s *ObjectStack) Print() string {
-	str := ""
-
-	for _, i := range s.Items {
-		str += i.Print() + " "
-	}
-
-	return str
-}
-
 func (s *ObjectStack) Push(o *Object) {
 	s.Items = append(s.Items, o)
 }

--- a/src/queue.go
+++ b/src/queue.go
@@ -44,23 +44,6 @@ func (q Queue) Value() interface{} {
 	return q.Items
 }
 
-func (q Queue) Print() string {
-	str := ""
-
-PrintLoop:
-	for {
-		select {
-		case i := <-q.Items:
-			str += i.Print()
-			str += " "
-		default:
-			break PrintLoop
-		}
-	}
-
-	return str
-}
-
 func (q Queue) Refl() string {
 	var s Stack
 	str := "{#" + fmt.Sprint(q.ID) + "# "
@@ -70,7 +53,7 @@ PrintLoop:
 		select {
 		case i := <-q.Items:
 			s.Push(i)
-			str += i.Print()
+			str += i.Refl()
 			str += " "
 		default:
 			break PrintLoop

--- a/src/stack.go
+++ b/src/stack.go
@@ -70,27 +70,6 @@ func (s Stack) Refl() string {
 	return str + ">"
 }
 
-func (s Stack) Print() string {
-	str := ""
-	for _, i := range s.Items {
-		switch i.(type) {
-		case Meta, *Meta:
-			str += "$ "
-		case *Stack:
-			if i.(*Stack).ID == s.ID {
-				str += "... "
-			} else {
-				str += i.Print() + " "
-			}
-		case nil:
-			str += "??? "
-		default:
-			str += i.Print() + " "
-		}
-	}
-	return str
-}
-
 func (s *Stack) Kind() string {
 	return s.Type
 }

--- a/src/vector.go
+++ b/src/vector.go
@@ -2,17 +2,6 @@ package main
 
 type V []datatypes
 
-func (v V) Print() string {
-	str := ""
-	for _, i := range v {
-		str += i.Print() + "\n"
-	}
-	if len(str) > 1 {
-		str = str[:len(str)-1]
-	}
-	return str
-}
-
 func (v V) Refl() string {
 	str := "("
 	for _, i := range v {


### PR DESCRIPTION
There was a bunch of duplicated code between `Print()` and `Refl()` and the former was not actually all that useful.

Instruction Changes:
- `say` outputs `T` as-is but calls `Refl()` (instead of `Print()`) for other datatypes before displaying it to the screen. It still suffixes a newline in either case.
- `print` only works on `T`, not on any other datatypes. (this change was made a while ago, but different from v0.1.1 and relevant to this change, so I'm mentioning here)
- Several datatypes called `Print()` from `Refl()` resulting in inconsistent behaviour, for instance `$ print` and `@ print` would display the `@`stack differently, this is no longer the case. 
- Note that `Print()` is not the `print` instruction, the `print` and `say` instructions will remain for convenience until there are standard library implementations.