### PR TITLE
Bugfix: Passing mutex by reference

### DIFF
--- a/src/meta.go
+++ b/src/meta.go
@@ -21,11 +21,11 @@ func NewMeta() *Meta {
 	return m
 }
 
-func (m Meta) Value() interface{} {
+func (m *Meta) Value() interface{} {
 	return m
 }
 
-func (m Meta) Refl() string {
+func (m *Meta) Refl() string {
 	str := "$" + fmt.Sprint(m.ID) + "#" + strconv.Itoa(m.Depth()) + "< "
 
 	for _, i := range m.Items {

--- a/src/stack.go
+++ b/src/stack.go
@@ -31,17 +31,15 @@ func NewSystemStack() *Stack {
 	return NewStack("system")
 }
 
-func (s Stack) Value() interface{} {
+func (s *Stack) Value() interface{} {
 	return s
 }
 
-func (s Stack) Refl() string {
+func (s *Stack) Refl() string {
 	str := s.ReflHeader()
 
 	for _, i := range s.Items {
 		switch i.(type) {
-		case Meta:
-			str += "$<...> "
 		case *Meta:
 			str += "$*<...> "
 		case *Stack:
@@ -50,8 +48,6 @@ func (s Stack) Refl() string {
 			} else {
 				str += i.Refl() + " "
 			}
-		case Stack:
-			panic("direct Stack reference: " + fmt.Sprint(i.(Stack).ID))
 		case nil:
 			str += "??? "
 		default:


### PR DESCRIPTION
Original:

> The current version of Golang seems to support this without problem.
> 
> I've tested everything and it seems to work just fine.
> 
> I'm quite certain that it used to refuse to compile because it no longer
> matched the interface.
> 
> I still suspect something is screwy because now some types pass by
> reference and some pass by value.

I refreshed my memory on Go Interfaces and it seems like it pretty much comes down to if you define an interface function on a reference then that interface only applies to the pointer type. However if you define the function on a value then the interface applies to both reference and value types.

What I suspect happened previously is that there was some code that relied on the false assumption that Stacks could be values on another Stack and this was breaking things. That doesn't really make any sense and is why the value type cases were removed in this PR as well.

See also:

- https://tour.golang.org/methods/9